### PR TITLE
Окно с оценкой перекрывает последнее сообщение оператора. SDK. bkc-940

### DIFF
--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -16,12 +16,12 @@
     <string name="chat_bottom_sheet_file_viewer_document_from_gallery">Document</string>
 
     <string name="urlChatScheme">https</string>
-    <string name="urlChatHost">cloud-dev-external.craft-talk.com</string>
-    <string name="urlChatNameSpace">channel_ce93c1</string>
+    <string name="urlChatHost">cloud-stage.craft-talk.com</string>
+    <string name="urlChatNameSpace">channel_296596d</string>
 
     <string name="webUrlChatScheme">https</string>
-    <string name="webUrlChatHost">cloud-dev-external.craft-talk.com</string>
-    <string name="webUrlChatNameSpace">channel_ce93c1</string>
+    <string name="webUrlChatHost">cloud-stage.craft-talk.com</string>
+    <string name="webUrlChatNameSpace">channel_296596d</string>
 
     <string name="salt">C~kW]cq76(a?m[UbJ)drw+Wh6>W[3Wsj</string>
     <string name="default_notification_channel_id">0</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,12 +16,12 @@
     <string name="chat_bottom_sheet_file_viewer_document_from_gallery">Документ</string>
 
     <string name="urlChatScheme">https</string>
-    <string name="urlChatHost">cloud-dev-external.craft-talk.com</string>
-    <string name="urlChatNameSpace">channel_ce93c1</string>
+    <string name="urlChatHost">cloud-stage.craft-talk.com</string>
+    <string name="urlChatNameSpace">channel_296596d</string>
 
     <string name="webUrlChatScheme">https</string>
-    <string name="webUrlChatHost">cloud-dev-external.craft-talk.com</string>
-    <string name="webUrlChatNameSpace">channel_ce93c1</string>
+    <string name="webUrlChatHost">cloud-stage.craft-talk.com</string>
+    <string name="webUrlChatNameSpace">channel_296596d</string>
 
     <string name="salt">C~kW]cq76(a?m[UbJ)drw+Wh6>W[3Wsj</string>
     <string name="default_notification_channel_id">0</string>

--- a/chat/src/main/java/com/crafttalk/chat/presentation/ChatViewModel.kt
+++ b/chat/src/main/java/com/crafttalk/chat/presentation/ChatViewModel.kt
@@ -4,13 +4,10 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.viewModelScope
 import androidx.paging.LivePagedListBuilder
 import androidx.paging.PagedList
 import com.crafttalk.chat.R
 import com.crafttalk.chat.domain.entity.auth.Visitor
-import com.crafttalk.chat.domain.entity.file.File as DomainFile
-import java.io.File as IOFile
 import com.crafttalk.chat.domain.entity.file.TypeFile
 import com.crafttalk.chat.domain.entity.internet.InternetConnectionState
 import com.crafttalk.chat.domain.interactors.*
@@ -25,6 +22,9 @@ import com.crafttalk.chat.utils.ChatParams
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import javax.inject.Inject
+import com.crafttalk.chat.domain.entity.file.File as DomainFile
+import java.io.File as IOFile
+
 
 class ChatViewModel
 @Inject constructor(
@@ -37,7 +37,6 @@ class ChatViewModel
     private val configurationInteractor: ConfigurationInteractor,
     private val context: Context
 ) : BaseViewModel() {
-
     var currentReadMessageTime = conditionInteractor.getCurrentReadMessageTime()
     var isAllHistoryLoaded = conditionInteractor.checkFlagAllHistoryLoaded()
     var initialLoadKey = conditionInteractor.getInitialLoadKey()

--- a/chat/src/main/java/com/crafttalk/chat/presentation/holders/HolderOperatorImageMessage.kt
+++ b/chat/src/main/java/com/crafttalk/chat/presentation/holders/HolderOperatorImageMessage.kt
@@ -17,8 +17,7 @@ class HolderOperatorImageMessage(
     view: View,
     private val download: (fileName: String, fileUrl: String, fileType: TypeFile) -> Unit,
     private val updateData: (id: String, height: Int, width: Int) -> Unit,
-    private val clickHandler: (imageName: String, imageUrl: String) -> Unit
-) : BaseViewHolder<ImageMessageItem>(view), View.OnClickListener {
+    private val clickHandler: (imageName: String, imageUrl: String) -> Unit) : BaseViewHolder<ImageMessageItem>(view), View.OnClickListener {
     private val contentContainer: View? = view.findViewById(R.id.content_container)
     private val warningContainer: ViewGroup? = view.findViewById(R.id.server_image_warning)
 

--- a/chat/src/main/res/layout/com_crafttalk_chat_layout_chat.xml
+++ b/chat/src/main/res/layout/com_crafttalk_chat_layout_chat.xml
@@ -30,7 +30,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/search_switch_place"
-        app:layout_constraintBottom_toTopOf="@id/reply_preview"
+        app:layout_constraintBottom_toTopOf="@id/user_feedback"
         tools:listitem="@layout/com_crafttalk_chat_item_server_text_message"
         tools:itemCount="1" />
 
@@ -113,20 +113,31 @@
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/lower_limit"
+        app:layout_constraintBottom_toTopOf="@+id/user_feedback"
         tools:visibility="visible" />
 
     <TextView
         android:id="@+id/company_name"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="@string/com_crafttalk_chat_name_company"
         android:background="@color/com_crafttalk_chat_white_transparent_75"
+        android:fontFamily="@font/com_crafttalk_chat_ubuntu_medium"
         android:gravity="right"
         android:paddingEnd="8dp"
         android:paddingBottom="8dp"
-        android:fontFamily="@font/com_crafttalk_chat_ubuntu_medium"
+        android:text="@string/com_crafttalk_chat_name_company"
         android:textFontWeight="700"
+        android:visibility="visible"
+        app:layout_constraintBottom_toTopOf="@id/lower_limit"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:visibility="visible" />
+
+    <include
+        android:id="@+id/user_feedback"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        layout="@layout/com_crafttalk_chat_layout_user_feedback"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/chat/src/main/res/layout/com_crafttalk_chat_layout_user_feedback.xml
+++ b/chat/src/main/res/layout/com_crafttalk_chat_layout_user_feedback.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingHorizontal="40dp"
+    android:paddingHorizontal="30dp"
     android:background="@color/com_crafttalk_chat_gray_f5f5f5">
 
     <TextView
@@ -13,8 +13,10 @@
         android:layout_height="wrap_content"
         android:text="@string/com_crafttalk_chat_feedback_title"
         android:gravity="center"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="16dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
@@ -26,7 +28,7 @@
         android:layout_height="40dp"
         android:src="@drawable/com_crafttalk_chat_ic_star_outline"
         android:tint="@color/com_crafttalk_chat_black"
-        android:layout_marginBottom="40dp"
+        android:layout_marginBottom="12dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/feedback_star_2"
         app:layout_constraintBottom_toTopOf="@id/close_feedback" />
@@ -37,7 +39,7 @@
         android:layout_height="40dp"
         android:src="@drawable/com_crafttalk_chat_ic_star_outline"
         android:tint="@color/com_crafttalk_chat_black"
-        android:layout_marginBottom="40dp"
+        android:layout_marginBottom="12dp"
         app:layout_constraintStart_toEndOf="@id/feedback_star_1"
         app:layout_constraintEnd_toStartOf="@+id/feedback_star_3"
         app:layout_constraintBottom_toTopOf="@id/close_feedback" />
@@ -48,7 +50,7 @@
         android:layout_height="40dp"
         android:src="@drawable/com_crafttalk_chat_ic_star_outline"
         android:tint="@color/com_crafttalk_chat_black"
-        android:layout_marginBottom="40dp"
+        android:layout_marginBottom="12dp"
         app:layout_constraintStart_toEndOf="@id/feedback_star_2"
         app:layout_constraintEnd_toStartOf="@+id/feedback_star_4"
         app:layout_constraintBottom_toTopOf="@id/close_feedback" />
@@ -59,7 +61,7 @@
         android:layout_height="40dp"
         android:src="@drawable/com_crafttalk_chat_ic_star_outline"
         android:tint="@color/com_crafttalk_chat_black"
-        android:layout_marginBottom="40dp"
+        android:layout_marginBottom="12dp"
         app:layout_constraintStart_toEndOf="@id/feedback_star_3"
         app:layout_constraintEnd_toStartOf="@+id/feedback_star_5"
         app:layout_constraintBottom_toTopOf="@id/close_feedback" />
@@ -70,7 +72,7 @@
         android:layout_height="40dp"
         android:src="@drawable/com_crafttalk_chat_ic_star_outline"
         android:tint="@color/com_crafttalk_chat_black"
-        android:layout_marginBottom="40dp"
+        android:layout_marginBottom="12dp"
         app:layout_constraintStart_toEndOf="@id/feedback_star_4"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toTopOf="@id/close_feedback" />
@@ -79,7 +81,7 @@
         android:id="@+id/close_feedback"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="16dp"
+        android:padding="8dp"
         android:src="@drawable/com_crafttalk_chat_ic_arrow_down"
         android:tint="@color/com_crafttalk_chat_gray_8d8d8d"
         app:layout_constraintStart_toStartOf="parent"

--- a/chat/src/main/res/layout/com_crafttalk_chat_view_host.xml
+++ b/chat/src/main/res/layout/com_crafttalk_chat_view_host.xml
@@ -123,16 +123,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         tools:visibility="gone" />
 
-    <include
-        android:id="@+id/user_feedback"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        layout="@layout/com_crafttalk_chat_layout_user_feedback"
-        android:visibility="gone"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        tools:visibility="gone" />
+
 
     <ProgressBar
         android:id="@+id/loading"


### PR DESCRIPTION
Окно оценки диалога больше не перекрывает, диалог с оператором

![изображение](https://github.com/crafttalk/crafttalk-android-sdk/assets/118670901/2622b76f-6543-4851-b398-8d7d32086bd3)
