### PR TITLE
Добавление пропущенной миграции

### DIFF
--- a/chat/src/main/java/com/crafttalk/chat/data/local/db/migrations/Migration_7_10.kt
+++ b/chat/src/main/java/com/crafttalk/chat/data/local/db/migrations/Migration_7_10.kt
@@ -1,0 +1,13 @@
+package com.crafttalk.chat.data.local.db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.crafttalk.chat.data.local.db.entity.MessageEntity
+
+object Migration_7_10: Migration(7, 10) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+
+        database.execSQL("DELETE FROM ${MessageEntity.TABLE_NAME}")
+
+    }
+}

--- a/chat/src/main/java/com/crafttalk/chat/di/modules/init/DBModule.kt
+++ b/chat/src/main/java/com/crafttalk/chat/di/modules/init/DBModule.kt
@@ -31,6 +31,7 @@ class DBModule {
             Migration_4_5,
             Migration_5_6,
             Migration_6_7,
+            Migration_7_10,
             Migration_9_10,
         )
         /**


### PR DESCRIPTION
Ещё одно исправление, переводящее пользователей с версии 7 на версию 10 через обычную миграцию. С версии 8 на версию 10 обновление произойдёт через `fallbackToDestructiveMigration`, при чистой установке у пользователей будет сразу версия 10.

