### PR TITLE
Миграция на Photo Picker API

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
 
 ext {
     retrofitVersion = '2.9.0'
-    kotlin_version = '1.5.30'
+    kotlin_version = '1.7.10'
     firebaseMessagingServiceVersion = '23.0.8'
     firebaseAnalyticsVersion = '21.1.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.30'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()

--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -42,13 +42,14 @@ ext {
     androidXRecyclerViewVersion = '1.2.1'
     materialVersion = '1.4.0'
     fragmentKtxVersion = '1.3.4'
+    activityKtxVersion = '1.7.0'
     socketVersion = '2.1.0'
     retrofitVersion = '2.9.0'
     coroutinesVersion = '1.6.4'
     glideVersion = '4.13.2'
     roomVersion = '2.2.4'
     okHttpVersion = '4.10.0'
-    kotlin_version = '1.5.30'
+    kotlin_version = '1.7.10'
     daggerVersion = '2.43.2'
     firebaseMessagingServiceVersion = '23.0.8'
     firebaseAnalyticsVersion = '21.1.1'
@@ -72,6 +73,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:$androidXRecyclerViewVersion"
     implementation "com.google.android.material:material:$materialVersion"
     implementation "androidx.fragment:fragment-ktx:$fragmentKtxVersion"
+    implementation "androidx.activity:activity-ktx:$activityKtxVersion"
 
     // DI
     implementation "com.google.dagger:dagger:$daggerVersion"

--- a/chat/src/main/java/com/crafttalk/chat/data/helper/converters/text/htmlConverter.kt
+++ b/chat/src/main/java/com/crafttalk/chat/data/helper/converters/text/htmlConverter.kt
@@ -105,6 +105,7 @@ fun String.convertFromBaseTextToNormalString(listTag: ArrayList<Tag>): String {
             selectUrl(this, "https")
             selectUrl(this, "wss")
         }
+        else -> Unit
     }
 //    selectUrl(this, "www")
     return this
@@ -345,6 +346,7 @@ fun String.convertFromHtmlTextToNormalString(listTag: ArrayList<Tag>): String {
                                 addTag(tagName.toString().trim(), listAttrsTag, result.lastIndex)
                         }
                     }
+                    else -> Unit
                 }
                 isSelectTag = false
                 isSingleTag = false

--- a/chat/src/main/java/com/crafttalk/chat/data/repository/PersonRepository.kt
+++ b/chat/src/main/java/com/crafttalk/chat/data/repository/PersonRepository.kt
@@ -29,6 +29,7 @@ class PersonRepository
             OperatorNameMode.ACTUAL -> {
                 messagesDao.updatePersonName(personId, currentPersonName)
             }
+            else -> Unit
         }
     }
 

--- a/chat/src/main/java/com/crafttalk/chat/domain/interactors/AuthInteractor.kt
+++ b/chat/src/main/java/com/crafttalk/chat/domain/interactors/AuthInteractor.kt
@@ -81,6 +81,7 @@ class AuthInteractor
                         conditionInteractor.saveCurrentReadMessageTime(lastTime)
                     }
                 }
+                else -> Unit
             }
         }
 
@@ -136,6 +137,7 @@ class AuthInteractor
                     chatEventListener = chatEventListener
                 )
             }
+            else -> Unit
         }
     }
 

--- a/chat/src/main/java/com/crafttalk/chat/domain/interactors/VisitorInteractor.kt
+++ b/chat/src/main/java/com/crafttalk/chat/domain/interactors/VisitorInteractor.kt
@@ -29,6 +29,7 @@ class VisitorInteractor
         when (ChatParams.authMode) {
             AuthType.AUTH_WITH_FORM -> visitorRepository.deleteVisitor()
             AuthType.AUTH_WITHOUT_FORM -> visitorRepository.setVisitorFromClient(null)
+            else -> Unit
         }
     }
 

--- a/chat/src/main/java/com/crafttalk/chat/presentation/ChatViewModelFactory.kt
+++ b/chat/src/main/java/com/crafttalk/chat/presentation/ChatViewModelFactory.kt
@@ -17,7 +17,7 @@ class ChatViewModelFactory constructor(
     private val context: Context
 ): ViewModelProvider.Factory {
 
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return ChatViewModel(
             authChatInteractor,
             messageInteractor,

--- a/chat/src/main/java/com/crafttalk/chat/presentation/feature/view_picture/ShowMediaDialog2.kt
+++ b/chat/src/main/java/com/crafttalk/chat/presentation/feature/view_picture/ShowMediaDialog2.kt
@@ -1,6 +1,5 @@
 package com.crafttalk.chat.presentation.feature.view_picture
 
-import android.Manifest.permission.READ_MEDIA_IMAGES
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.content.pm.PackageManager
 import android.os.Build
@@ -72,7 +71,7 @@ class ShowMediaDialog2 : AppCompatActivity(),View.OnClickListener {
                 if(Build.VERSION.SDK_INT < 32) {
                     storagePermission = ContextCompat.checkSelfPermission(baseContext, WRITE_EXTERNAL_STORAGE)}
                 else{
-                    storagePermission = ContextCompat.checkSelfPermission(baseContext, READ_MEDIA_IMAGES)
+                    storagePermission = PackageManager.PERMISSION_GRANTED
                 }
 
                 if (storagePermission == PackageManager.PERMISSION_GRANTED) {
@@ -93,9 +92,6 @@ class ShowMediaDialog2 : AppCompatActivity(),View.OnClickListener {
                     val code:Int = 1
                     if (Build.VERSION.SDK_INT < 32) {
                     ActivityCompat.requestPermissions(this, arrayOf(WRITE_EXTERNAL_STORAGE),code)}
-                    else{
-                        ActivityCompat.requestPermissions(this, arrayOf(READ_MEDIA_IMAGES),code)
-                    }
                 }
             }
         }

--- a/chat/src/main/java/com/crafttalk/chat/presentation/helper/converters/spanConverter.kt
+++ b/chat/src/main/java/com/crafttalk/chat/presentation/helper/converters/spanConverter.kt
@@ -51,6 +51,7 @@ fun String.convertToSpannableString(authorIsUser: Boolean, spanStructureList: Li
                         }
                     }
                 }
+                else -> Unit
             }
         }
         catch (e:Exception){

--- a/chat/src/main/java/com/crafttalk/chat/presentation/helper/downloaders/DownloadHelper.kt
+++ b/chat/src/main/java/com/crafttalk/chat/presentation/helper/downloaders/DownloadHelper.kt
@@ -77,11 +77,8 @@ fun downloadResource(
         ) { downloadFile(context, fileName, fileUrl, fileType, downloadListener, updateDownloadID) }
     } else
     {
-        //для версий старше или равных андроид 13
-        val permissions = arrayOf(
-            @Suppress ("all")
-            Manifest.permission.READ_MEDIA_IMAGES
-        )
+        //для версий старше или равных андроид 13 переехали на использование нового api
+        val permissions = emptyArray<String>()
         checkPermission(
             permissions,
             context,

--- a/chat/src/main/java/com/crafttalk/chat/presentation/helper/extensions/ImageView.kt
+++ b/chat/src/main/java/com/crafttalk/chat/presentation/helper/extensions/ImageView.kt
@@ -44,6 +44,7 @@ fun ImageView.setStatusMessage(message: MessageModel) {
             is GifMessageItem -> setColorFilter(ChatAttr.getInstance().colorUserGifMessageStatus)
             is FileMessageItem -> setColorFilter(ChatAttr.getInstance().colorUserFileMessageStatus)
             is UnionMessageItem -> setColorFilter(ChatAttr.getInstance().colorUserTextMessageStatus)
+            else -> Unit
         }
     } else {
         visibility = View.GONE

--- a/chat/src/main/java/com/crafttalk/chat/presentation/helper/file_viewer_helper/FileViewerHelper.kt
+++ b/chat/src/main/java/com/crafttalk/chat/presentation/helper/file_viewer_helper/FileViewerHelper.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.Build.VERSION_CODES.TIRAMISU
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import com.crafttalk.chat.R
@@ -22,6 +23,27 @@ import java.util.*
 
 class FileViewerHelper {
 
+    fun pickImages(
+        pickImage: ActivityResultLauncher<PickVisualMediaRequest>?,
+        pickSettings: PickVisualMediaRequest,
+        noPermission: (permissions: Array<String>, actionsAfterObtainingPermission: () -> Unit) -> Unit,
+        fragment: Fragment
+    ) {
+        fun pickFile() {
+            pickImage?.launch(pickSettings)
+        }
+        val permissions = if (Build.VERSION.SDK_INT >= TIRAMISU) {
+            arrayOf()
+        } else {
+            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+        checkPermission(
+            permissions,
+            fragment.requireContext(),
+            { noPermission(permissions) { pickFile() } }
+        ) { pickFile() }
+    }
+
     fun pickFiles(
         pickFile: ActivityResultLauncher<Pair<TypeFile, TypeMultiple>>?,
         pickSettings: Pair<TypeFile, TypeMultiple>,
@@ -32,7 +54,7 @@ class FileViewerHelper {
             pickFile?.launch(pickSettings)
         }
         val permissions = if (Build.VERSION.SDK_INT >= TIRAMISU) {
-            arrayOf(Manifest.permission.READ_MEDIA_IMAGES)
+            arrayOf()
         } else {
             arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
         }

--- a/chat/src/main/java/com/crafttalk/chat/presentation/helper/ui/holder.kt
+++ b/chat/src/main/java/com/crafttalk/chat/presentation/helper/ui/holder.kt
@@ -104,6 +104,7 @@ fun bindRepliedMessage(
                         )
                     }
                 }
+                else -> Unit
             }
         }
     }

--- a/chat/src/main/java/com/crafttalk/chat/presentation/holders/HolderOperatorUnionMessage.kt
+++ b/chat/src/main/java/com/crafttalk/chat/presentation/holders/HolderOperatorUnionMessage.kt
@@ -76,6 +76,7 @@ class HolderOperatorUnionMessage(
                     when (fileType) {
                         TypeFile.IMAGE -> clickImageHandler(name, url)
                         TypeFile.GIF -> clickGifHandler(name, url)
+                        else -> Unit
                     }
                 }
             }
@@ -180,6 +181,7 @@ class HolderOperatorUnionMessage(
                     loadMediaFile(item.id, item.file, updateData, false, true, warningContainer, true)
                 }
             }
+            else -> Unit
         }
     }
 

--- a/chat/src/main/java/com/crafttalk/chat/presentation/holders/HolderUserUnionMessage.kt
+++ b/chat/src/main/java/com/crafttalk/chat/presentation/holders/HolderUserUnionMessage.kt
@@ -68,6 +68,7 @@ class HolderUserUnionMessage(
                     when (fileType) {
                         TypeFile.IMAGE -> clickImageHandler(name, url)
                         TypeFile.GIF -> clickGifHandler(name, url)
+                        else -> Unit
                     }
                 }
             }
@@ -150,6 +151,7 @@ class HolderUserUnionMessage(
                     loadMediaFile(item.id, item.file, updateData, true, true, warningContainer, true)
                 }
             }
+            else -> Unit
         }
     }
 


### PR DESCRIPTION
В поставляемой библиотеке использовалось разрешение `READ_MEDIA_IMAGES`, которое Google [требует удалить при публикации в Google Play](https://support.google.com/googleplay/android-developer/answer/14115180).

В этом реквесте добавил Photo Picker API. Это потребовало новой зависимости `androidx.activity` версии `1.7.0` и поднятия версии Kotlin до минимально допустимой `1.7.10`. 

Поскольку библиотеки в проекте давно не обновлялись, пришлось добавить `default branch` в `when`, чтобы соответствовать новым требованиям Kotlin. Выглядит это как `else -> Unit` в нескольких местах и логику не ломает.