### PR TITLE
INGOS_B-21 Restore application context

### DIFF
--- a/chat/src/main/java/com/crafttalk/chat/initialization/Chat.kt
+++ b/chat/src/main/java/com/crafttalk/chat/initialization/Chat.kt
@@ -93,6 +93,7 @@ object Chat {
         ChatParams.fileReadTimeout = fileReadTimeout
         ChatParams.fileWriteTimeout = fileWriteTimeout
         ChatParams.fileCallTimeout = fileCallTimeout
+        appContext = context.applicationContext
         initDI(context.applicationContext)
     }
 


### PR DESCRIPTION
Фикс восстанавливает инициализацию Chat.appContext при запуске чата:

```kotlin
appContext = context.applicationContext
```

Контекст для DI остаётся прежним, но сам Chat.appContext тоже нужен, потому что часть SDK обращается к нему напрямую
Без этой строки appContext мог оставаться пустым после изменения инициализации контекста, из-за чего могли ломаться сценарии восстановления состояния чата