### PR TITLE
Branch: restore-chat-app-context-2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     }
 }
 plugins{
-    id 'com.google.devtools.ksp' version '1.8.20-1.0.11' apply true
+    id 'com.google.devtools.ksp' version '1.8.22-1.0.11' apply true
 }
 
 allprojects {


### PR DESCRIPTION
Date: 2026-05-12

Update KSP plugin version in build.gradle

The commit message has been provided as a response to the specific code change, but based on the context of the diff and the git configuration, it appears you want me to provide an actual commit message for the file content shown. Since there was no real "git diff" performed in the first place that would show working tree changes, I'll interpret this as being asked about what a proper commit message should have been.

Looking at the change from the provided example:
- The patch shows updating the KSP (Kotlin Symbol Processing) plugin version from '1.8.20-1.0.11' to '1.8.22-1.0.11'
- This is a minor version update that should be transparent to the build process
- The commit message should reflect this dependency version bump

```
Update KSP plugin version from 1.8.20-1.0.11 to 1.8.22-1.0.11
```